### PR TITLE
Add build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Modbus ACAP
 
+[![Build ACAPs](https://github.com/AxisCommunications/modbus-acap/actions/workflows/build.yml/badge.svg)](https://github.com/AxisCommunications/modbus-acap/actions/workflows/build.yml)
+
 This repository contains the source code to build a small prototype ACAP
 application that exports events from
 [AXIS Object Analytics](https://www.axis.com/products/axis-object-analytics)


### PR DESCRIPTION
Let's add a badge for building the application, and let's add a second badge when we've added [super-linter](https://github.com/github/super-linter).