### PR TITLE
build.yml: Docker is already present in ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,10 @@
 ---
 name: Build ACAPs
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, reopened]
+  push:
 
 jobs:
   build:
@@ -9,11 +12,7 @@ jobs:
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:
-      - uses: actions/checkout@v2
-      # Install Docker used by Makefile for our builds
-      - run: sudo apt-get update
-      - run: sudo apt-get --fix-broken install
-      - run: sudo apt-get install -y runc containerd docker.io
+      - uses: actions/checkout@v3
       # Test all Makefile targets and make sure the ACAP files are created
       - name: Build ACAPs
         run: make -j dockerbuild


### PR DESCRIPTION
### Describe your changes

There already is Docker available in GitHub's `ubuntu-latest` action image, so we can simplify our build action here.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
