### PR TITLE
modbusacap.c: Handle stateful Threshold events too

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
             "vendor": "Axis Communications AB",
             "embeddedSdkVersion": "2.0",
             "runMode": "respawn",
-            "version": "1.1.1"
+            "version": "1.1.2"
         },
         "configuration": {
             "paramConfig": [


### PR DESCRIPTION
### Describe your changes

These events have the topic2 string set as "Device1ScenarioXThreshold", where X = 1, 2 ... N. This patch also move the
ax_event_handler_unsubscribe prior to exiting the main loop, where they need to be.

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
