### PR TITLE
Move to ACAP 4 Native SDK and libmodbus version 3.1.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ARG LIBMODBUS_VERSION
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install additional build dependencies
+# hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y -f --no-install-recommends \
     autoconf \
     automake \
@@ -25,8 +26,8 @@ RUN curl -L https://github.com/stephane/libmodbus/archive/refs/tags/v$LIBMODBUS_
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN . /opt/axis/acapsdk/environment-setup* && \
     ./autogen.sh && \
-    ./configure --host=$ARCH --prefix=/usr --enable-static=yes --enable-shared=no && \
-    make -j $(nproc) install prefix=$SDKTARGETSYSROOT/usr
+    ./configure --host="$ARCH" --prefix=/usr --enable-static=yes --enable-shared=no && \
+    make -j "$(nproc)" install prefix="$SDKTARGETSYSROOT"/usr
 
 # Build ACAP package
 WORKDIR "$ACAP_BUILD_DIR"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,45 @@
-ARG ARCH=armv7hf
-ARG ACAP_SDK_VERSION=3.5
-ARG SDK_IMAGE=axisecp/acap-sdk
-ARG BUILD_DIR=/usr/local/src/server-acap
+ARG ARCH=aarch64
+ARG ACAP_SDK_VERSION=1.15
+ARG SDK_IMAGE=axisecp/acap-native-sdk
+ARG LIBMODBUS_VERSION=3.1.11
+ARG BUILD_DIR=/usr/local/src
+ARG ACAP_BUILD_DIR="$BUILD_DIR"/app
+ARG LIBMODBUS_BUILD_DIR="$BUILD_DIR"/libmodbus
 
-FROM $SDK_IMAGE:$ACAP_SDK_VERSION-$ARCH-ubuntu20.04 AS builder
-ARG BUILD_DIR
-WORKDIR "$BUILD_DIR"
+FROM $SDK_IMAGE:$ACAP_SDK_VERSION-$ARCH AS builder
+ARG ACAP_BUILD_DIR
+ARG LIBMODBUS_BUILD_DIR
+ARG LIBMODBUS_VERSION
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install additional build dependencies
+RUN apt-get update && apt-get install -y -f --no-install-recommends \
+    autoconf \
+    automake \
+    libtool
+
+# Build libmodbus
+WORKDIR "$LIBMODBUS_BUILD_DIR"
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -L https://github.com/stephane/libmodbus/archive/refs/tags/v$LIBMODBUS_VERSION.tar.gz | tar --strip-components=1 -xz
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN . /opt/axis/acapsdk/environment-setup* && \
+    ./autogen.sh && \
+    ./configure --host=$ARCH --prefix=/usr --enable-static=yes --enable-shared=no && \
+    make -j $(nproc) install prefix=$SDKTARGETSYSROOT/usr
+
+# Build ACAP package
+WORKDIR "$ACAP_BUILD_DIR"
 COPY LICENSE \
      Makefile \
      manifest.json \
      *.c \
      *.h \
      ./
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN . /opt/axis/acapsdk/environment-setup* && \
     acap-build .
 
 FROM scratch
-ARG BUILD_DIR
-COPY --from=builder "$BUILD_DIR"/*eap "$BUILD_DIR"/*LICENSE.txt /
+ARG ACAP_BUILD_DIR
+COPY --from=builder "$ACAP_BUILD_DIR"/*eap "$ACAP_BUILD_DIR"/*LICENSE.txt /

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,11 @@ PROG = modbusacap
 SRCS = $(wildcard *.c)
 OBJS = $(SRCS:.c=.o)
 STRIP ?= strip
+RM ?= rm -f
 
-PKGS = gio-2.0 glib-2.0 axevent axparameter
+PKGS = gio-2.0 glib-2.0 axevent axparameter libmodbus
 CFLAGS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags $(PKGS))
 LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs $(PKGS))
-
-# libmodbus
-LIBMODBUS_VERSION = 3.1.7
-LIBMODBUS_DIR = $(CURDIR)/libmodbus-$(LIBMODBUS_VERSION)
-LIBMODBUS = $(LIBMODBUS_DIR)/lib/libmodbus.a
-CFLAGS += -I $(LIBMODBUS_DIR)/include/modbus
-LDLIBS += $(LIBMODBUS)
 
 CFLAGS += -Wformat=2 -Wpointer-arith -Wbad-function-cast -Wstrict-prototypes -Wdisabled-optimization -Wall -Werror
 
@@ -22,21 +16,8 @@ CFLAGS += -Wformat=2 -Wpointer-arith -Wbad-function-cast -Wstrict-prototypes -Wd
 all: $(PROG)
 	$(STRIP) $(PROG)
 
-$(OBJS): $(LIBMODBUS)
-
 $(PROG): $(OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ $(LIBS) $(LDLIBS) -o $@
-
-# libmodbus targets
-$(LIBMODBUS_DIR):
-	curl -L https://libmodbus.org/releases/libmodbus-$(LIBMODBUS_VERSION).tar.gz | tar xz
-
-$(LIBMODBUS_DIR)/Makefile: | $(LIBMODBUS_DIR)
-	cd $(LIBMODBUS_DIR) && \
-	./configure --host=$(ARCH) --prefix=$(LIBMODBUS_DIR)
-
-$(LIBMODBUS): $(LIBMODBUS_DIR)/Makefile
-	make -C $(LIBMODBUS_DIR) -j install
 
 # docker build container targets
 %.eap:
@@ -45,11 +26,8 @@ $(LIBMODBUS): $(LIBMODBUS_DIR)/Makefile
 dockerbuild: armv7hf.eap aarch64.eap
 
 # clean targets
-3rd-party-clean:
-	make -C $(LIBMODBUS_DIR) clean
-
 clean:
-	rm -f $(PROG) *.o *.eap *LICENSE.txt pa*conf*
+	$(RM) $(PROG) *.o *.eap *LICENSE.txt pa*conf*
 
-very-clean: clean 3rd-party-clean
-	rm -rf *.eap *.eap.old eap $(LIBMODBUS_DIR)
+very-clean: clean
+	$(RM) *.old

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-*Copyright (C) 2023, Axis Communications AB, Lund, Sweden. All Rights Reserved.*
+*Copyright (C) 2024, Axis Communications AB, Lund, Sweden. All Rights Reserved.*
 
 # Modbus ACAP
 
@@ -6,8 +6,8 @@
 [![GitHub Super-Linter](https://github.com/AxisCommunications/modbus-acap/actions/workflows/super-linter.yml/badge.svg)](https://github.com/AxisCommunications/modbus-acap/actions/workflows/super-linter.yml)
 
 This repository contains the source code to build a small prototype
-[ACAP version 3](https://help.axis.com/acap-3-developer-guide)
-application that exports events from
+[ACAP version 4](https://axiscommunications.github.io/acap-documentation/)
+(native) application that exports events from
 [AXIS Object Analytics](https://www.axis.com/products/axis-object-analytics)
 (AOA) over
 [Modbus](https://en.wikipedia.org/wiki/Modbus) using
@@ -26,20 +26,12 @@ The build step creates `eap` (embedded application package) packages that can
 then be deployed on the target Axis device e.g. via the device's web UI.
 
 *For more information about the `eap` files, their content, and other ways to
-deploy, please see the
-[ACAP Developer Guide](https://help.axis.com/acap-3-developer-guide).*
+deploy, please see the documentation on how to
+[Develop ACAP applications](https://axiscommunications.github.io/acap-documentation/docs/develop/).*
 
-### On developer computer with ACAP SDK installed
-
-```sh
-# With the environment initialized, use:
-acap-build .
-```
-
-### Using ACAP SDK build container and Docker
-
-The handling of this is integrated in the [Makefile](Makefile), so if you have
-Docker and `make` on your computer all you need to do is:
+The build uses [Docker](https://www.docker.com/) and the containerized ACAP SDK.
+If you have `make` on your computer the Docker commands are nicely wrapped in
+the [Makefile](Makefile). All you need to do then is:
 
 ```sh
 make dockerbuild
@@ -74,7 +66,7 @@ The parameter settings are found in the three vertical dots menu:
 ![Web UI Screenshot](images/web_ui_param_settings.png)
 
 Select if the application should run in Server or Client mode and what AOA scenario's
-events it should subscribe to (default: Scenario 1). If you run in Client
+events it should subscribe to *(default: Scenario 1)*. If you run in Client
 mode, also make sure you have set the right hostname/IP address for the Modbus
 server you want to send the events to.
 
@@ -143,8 +135,8 @@ AOA status updates to the application log.
 
 > [!IMPORTANT]
 > The default Modbus/TCP port 502 requires running as a privileged user.
-> In order to run as a non-privileged user, this ACAP only allows ports in
-> the non-privileged range 1024–65535.
+> In order to run as a non-privileged user, this ACAP application only allows
+> ports in the non-privileged range 1024–65535.
 
 ## License
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,13 @@
 {
-    "schemaVersion": "1.3",
+    "schemaVersion": "1.7.0",
     "acapPackageConf": {
         "setup": {
             "appName": "modbusacap",
             "friendlyName": "Modbus Prototype", 
             "vendor": "Axis Communications AB",
-            "embeddedSdkVersion": "2.0",
+            "embeddedSdkVersion": "3.0",
             "runMode": "respawn",
-            "version": "1.1.2"
+            "version": "1.2.0"
         },
         "configuration": {
             "paramConfig": [


### PR DESCRIPTION
### Describe your changes
    
This patchset moves to the ACAP 4 Native SDK. This means we drop support for (really) old devices. If you need to build with the ACAP 3 SDK for old devices, please use the previous commit as your base since that will work fine for that.
    
With the move to ACAP 4 Native SDK, we can drop the support for this repo to be built with locally installed SDKs (that nobody uses these days anyway) and then move the build of libmodbus from `Makefile` into the `Dockerfile` instead.
    
This patchset also bumps libmodbus from version 3.1.7 to 3.1.11.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
