### PR TITLE
modbus_server.c: Add print of modbus address

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
             "vendor": "Axis Communications AB",
             "embeddedSdkVersion": "3.0",
             "runMode": "respawn",
-            "version": "1.2.3"
+            "version": "1.2.4"
         },
         "configuration": {
             "settingPage": "config.html",

--- a/modbus_server.c
+++ b/modbus_server.c
@@ -119,6 +119,8 @@ static void *run_modbus_server(void *run)
                 rlen);
             break;
         }
+        guint16 address = (req[8] << 8) | req[9];
+        LOG_I("%s/%s: Received request on address %d", __FILE__, __FUNCTION__, address);
         if (MODBUS_FC_WRITE_SINGLE_COIL == req[7])
         {
             LOG_I(


### PR DESCRIPTION
### Describe your changes

Log which incoming address the Modbus request has (but still act on all incoming requests) in server mode. This allows for better testing functionality when using the application in server mode.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
